### PR TITLE
Fix for UserMongoDB::getUserRepository()

### DIFF
--- a/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php
+++ b/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php
@@ -60,7 +60,7 @@ class UserMongoDB implements \ZfcUser\Mapper\UserInterface
 
     public function getUserRepository()
     {
-    	$class = ZfcUser::getOption('user_entity_class');
+    	$class = $this->options->getUserEntityClass();
         return $this->getDocumentManager()->getRepository($class);
     }
     


### PR DESCRIPTION
Fatal error: Class 'ZfcUserDoctrineMongoODM\Mapper\ZfcUser' not found in /project/vendor/jhuet/zfc-user-doctrine-mongo-odm/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php on line 63
