### PR TITLE
Update ZfcUser Version + fix fieldName error in XML annotation

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -13,11 +13,6 @@ class Module
         $sm      = $app->getServiceManager();
         $options = $sm->get('zfcuser_module_options');
 
-        // Add the default entity driver only if specified in configuration
-        if ($options->getEnableDefaultEntities()) {
-            $chain = $sm->get('doctrine.driver.odm_default');
-            $chain->addDriver(new XmlDriver(__DIR__ . '/config/xml'), 'ZfcUserDoctrineMongoODM\Document');
-        }
     }
 
     public function getAutoloaderConfig()

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.3.3",
         "zf-commons/zfc-user": "3.*",
-        "doctrine/doctrine-mongo-odm-module": "~1.0"
+        "doctrine/doctrine-mongo-odm-module": "^1.0"
     },
     "minimum-stability": "dev",
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.3.3",
         "zf-commons/zfc-user": "0.*",
-        "doctrine/doctrine-mongo-odm-module": "~0.9.1"
+        "doctrine/doctrine-mongo-odm-module": "~1.0"
     },
     "minimum-stability": "dev",
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zf-commons/zfc-user": "0.*",
+        "zf-commons/zfc-user": "3.*",
         "doctrine/doctrine-mongo-odm-module": "~1.0"
     },
     "minimum-stability": "dev",

--- a/config/xml/ZfcUserDoctrineMongoODM.Document.UserMappedSuperClass.dcm.xml
+++ b/config/xml/ZfcUserDoctrineMongoODM.Document.UserMappedSuperClass.dcm.xml
@@ -10,7 +10,7 @@
         
         <field fieldName="username" type="string" unique="true" nullable="true" />
         <field fieldName="email" type="string" unique="true" length="100" />
-        <field fieldName="display_name" type="string" length="50" nullable="true" />
+        <field fieldName="displayName" type="string" length="50" nullable="true" />
         <field fieldName="password" type="string" length="128" />
 
     </mapped-superclass>

--- a/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php
+++ b/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php
@@ -71,13 +71,13 @@ class UserMongoDB implements \ZfcUser\Mapper\UserInterface
         $dm->flush();
     }
     
-    public function insert($document, $tableName = null, HydratorInterface $hydrator = null)
+    public function insert(\ZfcUser\Entity\UserInterface $user)
     {
         $this->dm->persist($document);
         $this->dm->flush();
     }
 
-    public function update($document, $where = null, $tableName = null, HydratorInterface $hydrator = null)
+    public function update(\ZfcUser\Entity\UserInterface $user)
     {
         if (!$where) {
             $where = 'id = ' . $document->getId();

--- a/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php
+++ b/src/ZfcUserDoctrineMongoODM/Mapper/UserMongoDB.php
@@ -73,17 +73,15 @@ class UserMongoDB implements \ZfcUser\Mapper\UserInterface
     
     public function insert(\ZfcUser\Entity\UserInterface $user)
     {
-        $this->dm->persist($document);
+        $this->dm->persist($user);
         $this->dm->flush();
     }
 
     public function update(\ZfcUser\Entity\UserInterface $user)
     {
-        if (!$where) {
-            $where = 'id = ' . $document->getId();
-        }
+       
 
-        $this->dm->persist($document);
+        $this->dm->persist($user);
         $this->dm->flush();
     }
 }


### PR DESCRIPTION
The latest version of ZfcUser is compatible with ZF3.

The error in the XML annotation prevents doctrine module shell commands from running such as schema:create. This PR fixes this issue.
